### PR TITLE
Added 0.0.4

### DIFF
--- a/0.0.4/CMakeLists.txt
+++ b/0.0.4/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.10.0)
+project(cmake_wrapper)
+
+set(CONAN_BASIC_SETUP_ARGS)
+if(APPLE)
+    # When building shared libraries
+    # the binaries in the build tree need RPATHS
+    list(APPEND CONAN_BASIC_SETUP_ARGS KEEP_RPATHS)
+    set(CMAKE_SKIP_INSTALL_RPATH 1)
+endif()
+
+include(conanbuildinfo.cmake)
+conan_basic_setup(${CONAN_BASIC_SETUP_ARGS})
+
+add_subdirectory(source_subfolder)

--- a/0.0.4/conandata.yml
+++ b/0.0.4/conandata.yml
@@ -1,0 +1,5 @@
+sources:
+  "0.0.4":
+    url: "https://github.com/blackencino/emerald/archive/v0.0.4.tar.gz"
+    sha256: "2d9f77ab5c02b499f9fa0755684a9d9071f97bd1479bf63107def0a16496e199"
+

--- a/0.0.4/conanfile.py
+++ b/0.0.4/conanfile.py
@@ -1,0 +1,108 @@
+from conans import ConanFile, CMake, tools
+import os
+
+class EmeraldConan(ConanFile):
+    name = "emerald"
+    version = "0.0.4"
+    license = "Apache 2.0"
+    url = "https://github.com/blackencino/emerald"
+    description = "Emerald Simulation Libraries"
+    topics = ("conan", "simulation", "emerald", "sph", "fluids", "cfd", "vfx")
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "shared": [True, False], 
+        "fPIC": [True, False],
+        "build_guis": [True, False]
+        }
+    default_options = {
+        "shared": False, 
+        "fPIC": True,
+        "build_guis": True
+    }
+    generators = "cmake", "cmake_find_package"
+    exports_sources = "CMakeLists.txt"
+
+    requires = (
+        "fmt/7.1.3",
+        "boost/1.74.0",
+        "cxxopts/2.2.1",
+        "gsl-lite/0.37.0",
+        "openexr/2.5.3",
+        "alembic/1.7.16@blackencino/latest",
+        "outcome/2.1.5",
+        "spdlog/1.8.2",
+        "gtest/1.10.0",
+        "tbb/2020.0"
+    )
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def requirements(self):
+        self.options["tbb"].tbbmalloc = True
+        self.options["tbb"].tbbproxy = False
+        self.options["tbb"].shared = False
+
+        if self.options.build_guis:
+            self.requires.add("glfw/3.3.2")
+            self.requires.add("imgui/1.79")
+            self.requires.add("glad/0.1.34")
+
+            #self.options["glfw"].fPIC = True
+            #self.options["imgui"].fPIC = True
+
+            self.options["glad"].shared = False
+            #self.options["glad"].fPIC = True
+            self.options["glad"].spec = "gl"
+            self.options["glad"].no_loader = False
+            self.options["glad"].gl_profile = "core"
+            self.options["glad"].gl_version = "4.1"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        os.rename("emerald-{}".format(self.version), self._source_subfolder)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["EMERALD_BUILD_GUIS"] = self.options.build_guis
+        self._cmake.definitions["EMERALD_DO_TESTS"] = False
+
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE.txt", src=self._source_subfolder, dst="licenses")
+        cmake = self._configure_cmake()
+        cmake.install()
+        #tools.rmdir(os.path.join(self.package_folder, "share"))
+        #tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        #tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "emerald"
+        self.cpp_info.names["cmake_find_package_multi"] = "emerald"
+        self.cpp_info.names["pkg_config"] = "emerald"
+
+        self.cpp_info.libs = tools.collect_libs(self)
+
+
+
+
+

--- a/0.0.4/test_package/CMakeLists.txt
+++ b/0.0.4/test_package/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.1)
+project(PackageTest CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(example example.cpp)
+target_link_libraries(example ${CONAN_LIBS})
+target_compile_features(example PUBLIC cxx_std_17)
+    set_target_properties(example PROPERTIES 
+        CXX_STANDARD_REQUIRED ON 
+        CXX_EXTENSIONS OFF
+        POSITION_INDEPENDENT_CODE ON
+    )
+
+# CTest is a testing tool that can be used to test your project.
+# enable_testing()
+# add_test(NAME example
+#          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+#          COMMAND example)

--- a/0.0.4/test_package/conanfile.py
+++ b/0.0.4/test_package/conanfile.py
@@ -1,0 +1,25 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class EmeraldTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is
+        # in "test_package"
+        cmake.configure()
+        cmake.build()
+
+    def imports(self):
+        self.copy("*.dll", dst="bin", src="bin")
+        self.copy("*.dylib*", dst="bin", src="lib")
+        self.copy('*.so*', dst='bin', src='lib')
+
+    def test(self):
+        if not tools.cross_building(self):
+            os.chdir("bin")
+            self.run(".%sexample" % os.sep)

--- a/0.0.4/test_package/example.cpp
+++ b/0.0.4/test_package/example.cpp
@@ -1,0 +1,18 @@
+#include <emerald/shallow_weaver/simulation.h>
+
+#include <iostream>
+
+using namespace emerald::shallow_weaver;
+
+int main(int argc, char *argv[]) {
+  Simulation::Parameters params;
+  Simulation simulation{params};
+
+  for (int frame = 0; frame < simulation.parameters().num_batch_frames;
+       ++frame) {
+    simulation.step();
+    std::cout << "Frame: " << frame << std::endl;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
0.0.4 fixes a bunch of problems in AbcMeshesScene.

The transform interpolation was wrong, fixed and verified.

The time bracketing to get min & max time for the scene was also wrong, fixed and verified.

AbcMeshesScene is a terrible library, and needs to be replaced.